### PR TITLE
s3object uploads should use sha256 as checksum algorithm

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -67433,7 +67433,8 @@ function uploadFileS3(s3options, s3BucketName, archivePath, key, concurrency, ma
                 params: {
                     Bucket: s3BucketName,
                     Key: key,
-                    Body: fileStream
+                    Body: fileStream,
+                    ChecksumAlgorithm: 'SHA256'
                 }
             });
             parallelUpload.on('httpUploadProgress', (progress) => {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -67433,7 +67433,8 @@ function uploadFileS3(s3options, s3BucketName, archivePath, key, concurrency, ma
                 params: {
                     Bucket: s3BucketName,
                     Key: key,
-                    Body: fileStream
+                    Body: fileStream,
+                    ChecksumAlgorithm: 'SHA256'
                 }
             });
             parallelUpload.on('httpUploadProgress', (progress) => {

--- a/src/cache/internal/uploadUtils.ts
+++ b/src/cache/internal/uploadUtils.ts
@@ -31,7 +31,8 @@ export async function uploadFileS3(
       params: {
         Bucket: s3BucketName,
         Key: key,
-        Body: fileStream
+        Body: fileStream,
+        ChecksumAlgorithm: 'SHA256'
       }
     })
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change will explicitly add sha256 as checksum algorithm for uploads to s3.
It will change the default from crc64nvme to sha256 which do not require specific binaries to be distributed.

This pr superseeds https://github.com/sparebank1utvikling/actions-cache-s3/pull/35

## Motivation and Context
This fix is intended for fix the following errors:

```
Skipping CRC64NVME checksum validation: Please check whether you have installed the "@aws-sdk/crc64-nvme-crt" package explicitly.
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)
