### PR TITLE
Fix streaming restore using wrong key on fallback cache hit

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,0 +1,153 @@
+import { restoreCache } from "../src/cache";
+import * as cacheClient from "../src/cache/internal/cacheClient";
+import * as downloadUtils from "../src/cache/internal/downloadUtils";
+import * as cacheUtils from "../src/cache/internal/cacheUtils";
+import * as tar from "../src/cache/internal/tar";
+import { CompressionMethod } from "../src/cache/internal/constants";
+import { S3ClientConfig } from "@aws-sdk/client-s3";
+
+jest.mock("../src/cache/internal/cacheClient");
+jest.mock("../src/cache/internal/downloadUtils");
+jest.mock("../src/cache/internal/cacheUtils");
+
+const s3Options: S3ClientConfig = {
+    region: "eu-north-1",
+    credentials: {
+        accessKeyId: "test",
+        secretAccessKey: "test"
+    }
+};
+const s3BucketName = "test-bucket";
+
+beforeEach(() => {
+    jest.mocked(cacheUtils.getCompressionMethod).mockResolvedValue(
+        CompressionMethod.Zstd
+    );
+    jest.mocked(cacheUtils.createTempDirectory).mockResolvedValue("/tmp/test");
+    jest.mocked(cacheUtils.getCacheFileName).mockReturnValue("cache.tzst");
+    jest.mocked(cacheUtils.unlinkFile).mockResolvedValue();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+test("streaming restore with fallback key uses matched key, not primary key", async () => {
+    const primaryKey = "repo/project/abc123";
+    const fallbackKey = "repo/project/older-hash";
+    const restoreKeys = ["repo/project"];
+
+    jest.mocked(cacheClient.getCacheEntry).mockResolvedValue({
+        cacheKey: fallbackKey,
+        creationTime: new Date().toString(),
+        archiveLocation: "https://s3.amazonaws.com/"
+    });
+
+    jest.mocked(
+        downloadUtils.downloadAndExtractCacheFromS3Stream
+    ).mockResolvedValue({
+        key: fallbackKey,
+        size: 1024,
+        lastModified: new Date()
+    });
+
+    const result = await restoreCache(
+        ["node_modules"],
+        primaryKey,
+        s3Options,
+        s3BucketName,
+        restoreKeys,
+        { s3StreamDownload: true }
+    );
+
+    expect(result).toBe(fallbackKey);
+    expect(
+        downloadUtils.downloadAndExtractCacheFromS3Stream
+    ).toHaveBeenCalledWith(
+        fallbackKey,
+        s3Options,
+        s3BucketName,
+        CompressionMethod.Zstd
+    );
+    // Ensure it was NOT called with the primary key
+    expect(
+        downloadUtils.downloadAndExtractCacheFromS3Stream
+    ).not.toHaveBeenCalledWith(
+        primaryKey,
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+    );
+});
+
+test("streaming restore with exact primary key match uses primary key", async () => {
+    const primaryKey = "repo/project/abc123";
+
+    jest.mocked(cacheClient.getCacheEntry).mockResolvedValue({
+        cacheKey: primaryKey,
+        creationTime: new Date().toString(),
+        archiveLocation: "https://s3.amazonaws.com/"
+    });
+
+    jest.mocked(
+        downloadUtils.downloadAndExtractCacheFromS3Stream
+    ).mockResolvedValue({
+        key: primaryKey,
+        size: 2048,
+        lastModified: new Date()
+    });
+
+    const result = await restoreCache(
+        ["node_modules"],
+        primaryKey,
+        s3Options,
+        s3BucketName,
+        [],
+        { s3StreamDownload: true }
+    );
+
+    expect(result).toBe(primaryKey);
+    expect(
+        downloadUtils.downloadAndExtractCacheFromS3Stream
+    ).toHaveBeenCalledWith(
+        primaryKey,
+        s3Options,
+        s3BucketName,
+        CompressionMethod.Zstd
+    );
+});
+
+test("non-streaming restore with fallback key uses matched key", async () => {
+    const primaryKey = "repo/project/abc123";
+    const fallbackKey = "repo/project/older-hash";
+    const restoreKeys = ["repo/project"];
+
+    jest.mocked(cacheClient.getCacheEntry).mockResolvedValue({
+        cacheKey: fallbackKey,
+        creationTime: new Date().toString(),
+        archiveLocation: "https://s3.amazonaws.com/"
+    });
+
+    jest.mocked(cacheClient.downloadCache).mockResolvedValue();
+    jest.mocked(cacheUtils.getArchiveFileSizeInBytes).mockReturnValue(1024);
+
+    jest.spyOn(tar, "extractTar").mockResolvedValue(undefined as never);
+    jest.spyOn(tar, "listTar").mockResolvedValue(undefined as never);
+
+    const result = await restoreCache(
+        ["node_modules"],
+        primaryKey,
+        s3Options,
+        s3BucketName,
+        restoreKeys,
+        { s3StreamDownload: false }
+    );
+
+    expect(result).toBe(fallbackKey);
+    expect(cacheClient.downloadCache).toHaveBeenCalledWith(
+        expect.objectContaining({ cacheKey: fallbackKey }),
+        expect.any(String),
+        s3Options,
+        s3BucketName
+    );
+});

--- a/dist/restore/579.index.js
+++ b/dist/restore/579.index.js
@@ -1,0 +1,224 @@
+"use strict";
+exports.id = 579;
+exports.ids = [579];
+exports.modules = {
+
+/***/ 6579:
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+
+
+var schema = __webpack_require__(6890);
+var utilUtf8 = __webpack_require__(1577);
+
+class EventStreamSerde {
+    marshaller;
+    serializer;
+    deserializer;
+    serdeContext;
+    defaultContentType;
+    constructor({ marshaller, serializer, deserializer, serdeContext, defaultContentType, }) {
+        this.marshaller = marshaller;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+        this.serdeContext = serdeContext;
+        this.defaultContentType = defaultContentType;
+    }
+    async serializeEventStream({ eventStream, requestSchema, initialRequest, }) {
+        const marshaller = this.marshaller;
+        const eventStreamMember = requestSchema.getEventStreamMember();
+        const unionSchema = requestSchema.getMemberSchema(eventStreamMember);
+        unionSchema.getMemberSchemas();
+        const serializer = this.serializer;
+        const defaultContentType = this.defaultContentType;
+        const initialRequestMarker = Symbol("initialRequestMarker");
+        const eventStreamIterable = {
+            async *[Symbol.asyncIterator]() {
+                if (initialRequest) {
+                    const headers = {
+                        ":event-type": { type: "string", value: "initial-request" },
+                        ":message-type": { type: "string", value: "event" },
+                        ":content-type": { type: "string", value: defaultContentType },
+                    };
+                    serializer.write(requestSchema, initialRequest);
+                    const body = serializer.flush();
+                    yield {
+                        [initialRequestMarker]: true,
+                        headers,
+                        body,
+                    };
+                }
+                for await (const page of eventStream) {
+                    yield page;
+                }
+            },
+        };
+        return marshaller.serialize(eventStreamIterable, (event) => {
+            if (event[initialRequestMarker]) {
+                return {
+                    headers: event.headers,
+                    body: event.body,
+                };
+            }
+            const unionMember = Object.keys(event).find((key) => {
+                return key !== "__type";
+            }) ?? "";
+            const { additionalHeaders, body, eventType, explicitPayloadContentType } = this.writeEventBody(unionMember, unionSchema, event);
+            const headers = {
+                ":event-type": { type: "string", value: eventType },
+                ":message-type": { type: "string", value: "event" },
+                ":content-type": { type: "string", value: explicitPayloadContentType ?? defaultContentType },
+                ...additionalHeaders,
+            };
+            return {
+                headers,
+                body,
+            };
+        });
+    }
+    async deserializeEventStream({ response, responseSchema, initialResponseContainer, }) {
+        const marshaller = this.marshaller;
+        const eventStreamMember = responseSchema.getEventStreamMember();
+        const unionSchema = responseSchema.getMemberSchema(eventStreamMember);
+        const memberSchemas = unionSchema.getMemberSchemas();
+        const initialResponseMarker = Symbol("initialResponseMarker");
+        const asyncIterable = marshaller.deserialize(response.body, async (event) => {
+            const unionMember = Object.keys(event).find((key) => {
+                return key !== "__type";
+            }) ?? "";
+            if (unionMember === "initial-response") {
+                const dataObject = await this.deserializer.read(responseSchema, event[unionMember].body);
+                delete dataObject[eventStreamMember];
+                return {
+                    [initialResponseMarker]: true,
+                    ...dataObject,
+                };
+            }
+            else if (unionMember in memberSchemas) {
+                const eventStreamSchema = memberSchemas[unionMember];
+                return {
+                    [unionMember]: await this.deserializer.read(eventStreamSchema, event[unionMember].body),
+                };
+            }
+            else {
+                return {
+                    $unknown: event,
+                };
+            }
+        });
+        const asyncIterator = asyncIterable[Symbol.asyncIterator]();
+        const firstEvent = await asyncIterator.next();
+        if (firstEvent.done) {
+            return asyncIterable;
+        }
+        if (firstEvent.value?.[initialResponseMarker]) {
+            if (!responseSchema) {
+                throw new Error("@smithy::core/protocols - initial-response event encountered in event stream but no response schema given.");
+            }
+            for (const [key, value] of Object.entries(firstEvent.value)) {
+                initialResponseContainer[key] = value;
+            }
+        }
+        return {
+            async *[Symbol.asyncIterator]() {
+                if (!firstEvent?.value?.[initialResponseMarker]) {
+                    yield firstEvent.value;
+                }
+                while (true) {
+                    const { done, value } = await asyncIterator.next();
+                    if (done) {
+                        break;
+                    }
+                    yield value;
+                }
+            },
+        };
+    }
+    writeEventBody(unionMember, unionSchema, event) {
+        const serializer = this.serializer;
+        let eventType = unionMember;
+        let explicitPayloadMember = null;
+        let explicitPayloadContentType;
+        const isKnownSchema = unionSchema.hasMemberSchema(unionMember);
+        const additionalHeaders = {};
+        if (!isKnownSchema) {
+            const [type, value] = event[unionMember];
+            eventType = type;
+            serializer.write(schema.SCHEMA.DOCUMENT, value);
+        }
+        else {
+            const eventSchema = unionSchema.getMemberSchema(unionMember);
+            if (eventSchema.isStructSchema()) {
+                for (const [memberName, memberSchema] of eventSchema.structIterator()) {
+                    const { eventHeader, eventPayload } = memberSchema.getMergedTraits();
+                    if (eventPayload) {
+                        explicitPayloadMember = memberName;
+                        break;
+                    }
+                    else if (eventHeader) {
+                        const value = event[unionMember][memberName];
+                        let type = "binary";
+                        if (memberSchema.isNumericSchema()) {
+                            if ((-2) ** 31 <= value && value <= 2 ** 31 - 1) {
+                                type = "integer";
+                            }
+                            else {
+                                type = "long";
+                            }
+                        }
+                        else if (memberSchema.isTimestampSchema()) {
+                            type = "timestamp";
+                        }
+                        else if (memberSchema.isStringSchema()) {
+                            type = "string";
+                        }
+                        else if (memberSchema.isBooleanSchema()) {
+                            type = "boolean";
+                        }
+                        if (value != null) {
+                            additionalHeaders[memberName] = {
+                                type,
+                                value,
+                            };
+                            delete event[unionMember][memberName];
+                        }
+                    }
+                }
+                if (explicitPayloadMember !== null) {
+                    const payloadSchema = eventSchema.getMemberSchema(explicitPayloadMember);
+                    if (payloadSchema.isBlobSchema()) {
+                        explicitPayloadContentType = "application/octet-stream";
+                    }
+                    else if (payloadSchema.isStringSchema()) {
+                        explicitPayloadContentType = "text/plain";
+                    }
+                    serializer.write(payloadSchema, event[unionMember][explicitPayloadMember]);
+                }
+                else {
+                    serializer.write(eventSchema, event[unionMember]);
+                }
+            }
+            else {
+                throw new Error("@smithy/core/event-streams - non-struct member not supported in event stream union.");
+            }
+        }
+        const messageSerialization = serializer.flush();
+        const body = typeof messageSerialization === "string"
+            ? (this.serdeContext?.utf8Decoder ?? utilUtf8.fromUtf8)(messageSerialization)
+            : messageSerialization;
+        return {
+            body,
+            eventType,
+            explicitPayloadContentType,
+            additionalHeaders,
+        };
+    }
+}
+
+exports.EventStreamSerde = EventStreamSerde;
+
+
+/***/ })
+
+};
+;

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -66777,6 +66777,13 @@ function restoreCacheS3(paths, primaryKey, s3Options, s3BucketName, restoreKeys,
                 // Cache not found
                 return undefined;
             }
+            const isExactMatch = cacheEntry.cacheKey === primaryKey;
+            if (isExactMatch) {
+                core.info(`Cache hit on primary key: ${primaryKey}`);
+            }
+            else {
+                core.info(`Primary key miss: ${primaryKey}. Restored from fallback key: ${cacheEntry.cacheKey}`);
+            }
             if (options === null || options === void 0 ? void 0 : options.lookupOnly) {
                 core.info("Lookup only - skipping download");
                 return cacheEntry.cacheKey;
@@ -66796,7 +66803,7 @@ function restoreCacheS3(paths, primaryKey, s3Options, s3BucketName, restoreKeys,
                 return cacheEntry.cacheKey;
             }
             else {
-                const info = yield (0, downloadUtils_1.downloadAndExtractCacheFromS3Stream)(primaryKey, s3Options, s3BucketName, compressionMethod);
+                const info = yield (0, downloadUtils_1.downloadAndExtractCacheFromS3Stream)(cacheEntry.cacheKey, s3Options, s3BucketName, compressionMethod);
                 const size = Math.round(((_b = info.size) !== null && _b !== void 0 ? _b : 0) / (1024 * 1024));
                 core.info(`Cache restored successfully for key: ${info.key} of size: ${size} MB (${info.size} B) and last modified: ${(_c = info.lastModified) === null || _c === void 0 ? void 0 : _c.toISOString()}`);
                 return cacheEntry.cacheKey;

--- a/dist/save/579.index.js
+++ b/dist/save/579.index.js
@@ -1,0 +1,224 @@
+"use strict";
+exports.id = 579;
+exports.ids = [579];
+exports.modules = {
+
+/***/ 6579:
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+
+
+var schema = __webpack_require__(6890);
+var utilUtf8 = __webpack_require__(1577);
+
+class EventStreamSerde {
+    marshaller;
+    serializer;
+    deserializer;
+    serdeContext;
+    defaultContentType;
+    constructor({ marshaller, serializer, deserializer, serdeContext, defaultContentType, }) {
+        this.marshaller = marshaller;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+        this.serdeContext = serdeContext;
+        this.defaultContentType = defaultContentType;
+    }
+    async serializeEventStream({ eventStream, requestSchema, initialRequest, }) {
+        const marshaller = this.marshaller;
+        const eventStreamMember = requestSchema.getEventStreamMember();
+        const unionSchema = requestSchema.getMemberSchema(eventStreamMember);
+        unionSchema.getMemberSchemas();
+        const serializer = this.serializer;
+        const defaultContentType = this.defaultContentType;
+        const initialRequestMarker = Symbol("initialRequestMarker");
+        const eventStreamIterable = {
+            async *[Symbol.asyncIterator]() {
+                if (initialRequest) {
+                    const headers = {
+                        ":event-type": { type: "string", value: "initial-request" },
+                        ":message-type": { type: "string", value: "event" },
+                        ":content-type": { type: "string", value: defaultContentType },
+                    };
+                    serializer.write(requestSchema, initialRequest);
+                    const body = serializer.flush();
+                    yield {
+                        [initialRequestMarker]: true,
+                        headers,
+                        body,
+                    };
+                }
+                for await (const page of eventStream) {
+                    yield page;
+                }
+            },
+        };
+        return marshaller.serialize(eventStreamIterable, (event) => {
+            if (event[initialRequestMarker]) {
+                return {
+                    headers: event.headers,
+                    body: event.body,
+                };
+            }
+            const unionMember = Object.keys(event).find((key) => {
+                return key !== "__type";
+            }) ?? "";
+            const { additionalHeaders, body, eventType, explicitPayloadContentType } = this.writeEventBody(unionMember, unionSchema, event);
+            const headers = {
+                ":event-type": { type: "string", value: eventType },
+                ":message-type": { type: "string", value: "event" },
+                ":content-type": { type: "string", value: explicitPayloadContentType ?? defaultContentType },
+                ...additionalHeaders,
+            };
+            return {
+                headers,
+                body,
+            };
+        });
+    }
+    async deserializeEventStream({ response, responseSchema, initialResponseContainer, }) {
+        const marshaller = this.marshaller;
+        const eventStreamMember = responseSchema.getEventStreamMember();
+        const unionSchema = responseSchema.getMemberSchema(eventStreamMember);
+        const memberSchemas = unionSchema.getMemberSchemas();
+        const initialResponseMarker = Symbol("initialResponseMarker");
+        const asyncIterable = marshaller.deserialize(response.body, async (event) => {
+            const unionMember = Object.keys(event).find((key) => {
+                return key !== "__type";
+            }) ?? "";
+            if (unionMember === "initial-response") {
+                const dataObject = await this.deserializer.read(responseSchema, event[unionMember].body);
+                delete dataObject[eventStreamMember];
+                return {
+                    [initialResponseMarker]: true,
+                    ...dataObject,
+                };
+            }
+            else if (unionMember in memberSchemas) {
+                const eventStreamSchema = memberSchemas[unionMember];
+                return {
+                    [unionMember]: await this.deserializer.read(eventStreamSchema, event[unionMember].body),
+                };
+            }
+            else {
+                return {
+                    $unknown: event,
+                };
+            }
+        });
+        const asyncIterator = asyncIterable[Symbol.asyncIterator]();
+        const firstEvent = await asyncIterator.next();
+        if (firstEvent.done) {
+            return asyncIterable;
+        }
+        if (firstEvent.value?.[initialResponseMarker]) {
+            if (!responseSchema) {
+                throw new Error("@smithy::core/protocols - initial-response event encountered in event stream but no response schema given.");
+            }
+            for (const [key, value] of Object.entries(firstEvent.value)) {
+                initialResponseContainer[key] = value;
+            }
+        }
+        return {
+            async *[Symbol.asyncIterator]() {
+                if (!firstEvent?.value?.[initialResponseMarker]) {
+                    yield firstEvent.value;
+                }
+                while (true) {
+                    const { done, value } = await asyncIterator.next();
+                    if (done) {
+                        break;
+                    }
+                    yield value;
+                }
+            },
+        };
+    }
+    writeEventBody(unionMember, unionSchema, event) {
+        const serializer = this.serializer;
+        let eventType = unionMember;
+        let explicitPayloadMember = null;
+        let explicitPayloadContentType;
+        const isKnownSchema = unionSchema.hasMemberSchema(unionMember);
+        const additionalHeaders = {};
+        if (!isKnownSchema) {
+            const [type, value] = event[unionMember];
+            eventType = type;
+            serializer.write(schema.SCHEMA.DOCUMENT, value);
+        }
+        else {
+            const eventSchema = unionSchema.getMemberSchema(unionMember);
+            if (eventSchema.isStructSchema()) {
+                for (const [memberName, memberSchema] of eventSchema.structIterator()) {
+                    const { eventHeader, eventPayload } = memberSchema.getMergedTraits();
+                    if (eventPayload) {
+                        explicitPayloadMember = memberName;
+                        break;
+                    }
+                    else if (eventHeader) {
+                        const value = event[unionMember][memberName];
+                        let type = "binary";
+                        if (memberSchema.isNumericSchema()) {
+                            if ((-2) ** 31 <= value && value <= 2 ** 31 - 1) {
+                                type = "integer";
+                            }
+                            else {
+                                type = "long";
+                            }
+                        }
+                        else if (memberSchema.isTimestampSchema()) {
+                            type = "timestamp";
+                        }
+                        else if (memberSchema.isStringSchema()) {
+                            type = "string";
+                        }
+                        else if (memberSchema.isBooleanSchema()) {
+                            type = "boolean";
+                        }
+                        if (value != null) {
+                            additionalHeaders[memberName] = {
+                                type,
+                                value,
+                            };
+                            delete event[unionMember][memberName];
+                        }
+                    }
+                }
+                if (explicitPayloadMember !== null) {
+                    const payloadSchema = eventSchema.getMemberSchema(explicitPayloadMember);
+                    if (payloadSchema.isBlobSchema()) {
+                        explicitPayloadContentType = "application/octet-stream";
+                    }
+                    else if (payloadSchema.isStringSchema()) {
+                        explicitPayloadContentType = "text/plain";
+                    }
+                    serializer.write(payloadSchema, event[unionMember][explicitPayloadMember]);
+                }
+                else {
+                    serializer.write(eventSchema, event[unionMember]);
+                }
+            }
+            else {
+                throw new Error("@smithy/core/event-streams - non-struct member not supported in event stream union.");
+            }
+        }
+        const messageSerialization = serializer.flush();
+        const body = typeof messageSerialization === "string"
+            ? (this.serdeContext?.utf8Decoder ?? utilUtf8.fromUtf8)(messageSerialization)
+            : messageSerialization;
+        return {
+            body,
+            eventType,
+            explicitPayloadContentType,
+            additionalHeaders,
+        };
+    }
+}
+
+exports.EventStreamSerde = EventStreamSerde;
+
+
+/***/ })
+
+};
+;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -66777,6 +66777,13 @@ function restoreCacheS3(paths, primaryKey, s3Options, s3BucketName, restoreKeys,
                 // Cache not found
                 return undefined;
             }
+            const isExactMatch = cacheEntry.cacheKey === primaryKey;
+            if (isExactMatch) {
+                core.info(`Cache hit on primary key: ${primaryKey}`);
+            }
+            else {
+                core.info(`Primary key miss: ${primaryKey}. Restored from fallback key: ${cacheEntry.cacheKey}`);
+            }
             if (options === null || options === void 0 ? void 0 : options.lookupOnly) {
                 core.info("Lookup only - skipping download");
                 return cacheEntry.cacheKey;
@@ -66796,7 +66803,7 @@ function restoreCacheS3(paths, primaryKey, s3Options, s3BucketName, restoreKeys,
                 return cacheEntry.cacheKey;
             }
             else {
-                const info = yield (0, downloadUtils_1.downloadAndExtractCacheFromS3Stream)(primaryKey, s3Options, s3BucketName, compressionMethod);
+                const info = yield (0, downloadUtils_1.downloadAndExtractCacheFromS3Stream)(cacheEntry.cacheKey, s3Options, s3BucketName, compressionMethod);
                 const size = Math.round(((_b = info.size) !== null && _b !== void 0 ? _b : 0) / (1024 * 1024));
                 core.info(`Cache restored successfully for key: ${info.key} of size: ${size} MB (${info.size} B) and last modified: ${(_c = info.lastModified) === null || _c === void 0 ? void 0 : _c.toISOString()}`);
                 return cacheEntry.cacheKey;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -132,6 +132,15 @@ async function restoreCacheS3(
             return undefined;
         }
 
+        const isExactMatch = cacheEntry.cacheKey === primaryKey;
+        if (isExactMatch) {
+            core.info(`Cache hit on primary key: ${primaryKey}`);
+        } else {
+            core.info(
+                `Primary key miss: ${primaryKey}. Restored from fallback key: ${cacheEntry.cacheKey}`
+            );
+        }
+
         if (options?.lookupOnly) {
             core.info("Lookup only - skipping download");
             return cacheEntry.cacheKey;
@@ -168,7 +177,7 @@ async function restoreCacheS3(
             return cacheEntry.cacheKey;
         } else {
             const info = await downloadAndExtractCacheFromS3Stream(
-                primaryKey,
+                cacheEntry.cacheKey!,
                 s3Options,
                 s3BucketName,
                 compressionMethod


### PR DESCRIPTION
## Summary
- **Bug fix:** When the primary cache key misses and a `restore-keys` prefix matches, the streaming download path (default) incorrectly used the primary key instead of the matched fallback key to download from S3, causing a `NoSuchKey` error. Non-streaming path was unaffected.
- **Improved logging:** Added clear `core.info` messages indicating whether the cache was restored from the primary key or a fallback key.
- **Tests:** Added `__tests__/cache.test.ts` with 3 tests covering streaming fallback, streaming primary hit, and non-streaming fallback.

The one-line fix in `src/cache.ts`: changed `primaryKey` to `cacheEntry.cacheKey!` in the `downloadAndExtractCacheFromS3Stream()` call.

## Test plan
- [x] All 58 existing + new tests pass (`npx jest`)
- [ ] Verify in a real workflow that fallback restore-key matching works with streaming download (default)
- [ ] Verify primary key exact match still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)